### PR TITLE
🐛 Fix: appleOauth redirect오류 수정

### DIFF
--- a/src/utils/LoginAndRegister/AppleLogin.ts
+++ b/src/utils/LoginAndRegister/AppleLogin.ts
@@ -10,7 +10,7 @@ export const appleLogin = async () => {
     redirectURI: `${REDIRECT_URI}`,
     state: 'previewInsure',
     nonce: '821',
-    usePopup: true,
+    usePopup: false,
   });
 
   try {


### PR DESCRIPTION
- redirectURI로 이동하지 않는 오류 수정
-  usePopup: true 로 설정

## #️⃣연관된 이슈


## 📝작업 내용 요약

이전 apple OAuth작업 연장
popup을 띄우지 않고 다음 페이지로 넘어가게끔 설정

### 스크린샷 (선택)
![화면 기록 2024-07-30 오후 6 39 43](https://github.com/user-attachments/assets/5b42d7f4-e82f-490d-afb7-073531cb6574)

