### PR TITLE
🐛 Fix: ios기기에만 ios 디자인 설정

### DIFF
--- a/src/components/InsueBoarding/Step4.tsx
+++ b/src/components/InsueBoarding/Step4.tsx
@@ -42,7 +42,6 @@ function Step4({ goNextStep, goPreviousStep, setSelectedInsures, setToSelectInsu
         setFake(false);
         setSelectedCards([]);
       }, 100);
-      // setSelectedCards([]);
     } else {
       setFake(false);
     }

--- a/src/components/commons/Selector.tsx
+++ b/src/components/commons/Selector.tsx
@@ -78,14 +78,12 @@ const IconBox = styled.div<{ platform: string }>`
     // 767 < 
     width: 13px;
     height: 10px;
-    left: -100%;
-
+    position: absolute;
+    left: 10%;
+    bottom:25%;
     //
-    position: ${({ platform }: any) => platform === 'ios' && 'absolute'};
-    left:${({ platform }: any) => platform === 'ios' && '10%'};
-    bottom:${({ platform }: any) => platform === 'ios' && '25%'};
-    width: ${({ platform }: any) => platform === 'ios' && '13px'};  //4rem
-    height: ${({ platform }: any) => platform === 'ios' && '10px'};  //4rem
+    bottom:${({ platform }: any) => platform === 'ios' && '15%'};
+  
   `}
 `;
 

--- a/src/stores/useStore.ts
+++ b/src/stores/useStore.ts
@@ -61,7 +61,7 @@ export const useStore = create<State>()(
       nickName: '',
       isLogin: false,
       temporaryToken: '',
-      platform: 'ios', // 원래는 빈값 -> 웹에서도 깨지지 않기 일단 ios로
+      platform: '', // 원래는 빈값 -> 웹에서도 깨지지 않기 일단 ios로
       login: (token, nickName) => {
         set({ accessToken: token, nickName, isLogin: true, temporaryToken: '' });
       },


### PR DESCRIPTION


## #️⃣연관된 이슈



## 📝작업 내용 요약

- 웹뷰 통신이 성공적이므로 useStore의 Platform 값 정상화
- step4 안드로이드,웹 정상화 확인
- 셀렉터 ios/웹 디자인 차이 설정

### 스크린샷 (선택)
