### PR TITLE
🐛 Fix: ios기기 애플로그인 연결 시 새탭으로 열기

### DIFF
--- a/src/utils/LoginAndRegister/AppleLogin.ts
+++ b/src/utils/LoginAndRegister/AppleLogin.ts
@@ -5,6 +5,7 @@ const REDIRECT_URI = window.location.protocol + '//' + window.location.host + '/
 const APPLE_CLIENT_ID2 = import.meta.env.VITE_APP_APPLE_CLIENT_ID2;
 const APPLE_SERVER_URI = import.meta.env.VITE_APP_APPLE_REDIRECT_SERVER_URL;
 import { openNewTab } from '@utils/common/openNewTab';
+import { useStore } from '@stores/useStore';
 
 export const appleLogin = async () => {
   // const RESPONSE_TYPE = 'code id_token'; // 요청하는 응답 타입
@@ -19,6 +20,7 @@ export const appleLogin = async () => {
   //   `&scope=${encodeURIComponent('')}` +
   //   `&state=${encodeURIComponent('previewInsure')}` +
   //   `&nonce=${encodeURIComponent('821')}`;
+  const { platform } = useStore.getState();
 
   const AUTH_URL2 =
     `https://appleid.apple.com/auth/authorize?` +
@@ -30,8 +32,13 @@ export const appleLogin = async () => {
 
   // 브라우저에서 Apple 로그인 페이지로 리디렉션
   try {
-    window.location.href = AUTH_URL2;
+    // window.location.href = AUTH_URL2;
     // openNewTab(AUTH_URL2);
+    if (platform === 'ios') {
+      openNewTab(AUTH_URL2);
+    } else {
+      window.location.href = AUTH_URL2;
+    }
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION


## #️⃣연관된 이슈



## 📝작업 내용 요약

- ios기기에서 애플로그인 시 뒤로라기 가능
- 구글로그인은 403에러 발생

### 스크린샷 (선택)
